### PR TITLE
feat: add tf-account to support multiple customers 

### DIFF
--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -151,7 +151,7 @@ jobs:
         run: |
           path='plan'
           txt_path='plan.txt'
-          var_file=tenants/${{ steps.workspace.outputs.workspace}}.tfvars
+          var_file=customers/${{ steps.workspace.outputs.workspace}}.tfvars
           touch $txt_path && echo "path=${txt_path}" >> $GITHUB_OUTPUT
           plan_args=()
           if [ -e "$var_file" ]; then           


### PR DESCRIPTION
**Description**
- Borrowed from [here](https://github.com/observeinc/.github/blob/main/.github/workflows/tf-account.yaml) to support applying `tf-account-*` to multiple customers 
- Additional customer is passed in as an optional input to workflow (`additional_customers`) 
- This additional customer gets mapped to be a new workspace. 
- Plan comments has been updated
- New workflow step to create /select workspaces and configure the correct backend
- Backend for non-default:    `-backend-config="workspace_key_prefix=${{ github.event.repository.name }}" `
which gets mapped in the bucket as `<repo_name>/<workspace>/<key>` where key is `<repo_name>/tf-state`

<img width="1195" alt="Screenshot 2023-08-21 at 10 34 53 AM" src="https://github.com/observeinc/terraform-account-workflows/assets/124205220/d44a3b5c-cffb-499e-a204-ca94b749e879">




Note: For terraform to apply this workspace, additional customer MUST have a mapping present in the tf-account `provider.tf`!
See: https://github.com/observeinc/tf-account-dual-terraform/pull/2/files

**Testing**
- Test PR to run this workflow call with two plans against two workspaces (https://github.com/observeinc/tf-account-dual-terraform/pull/2)
- Workspace 1 is default. Workspace 2 (supplied) is called `cap2` which is mapped as `OBSERVE_CUSTOMER_2` secrets key 
- The secret key can be anything (eg: `OBSERVE_CUSTOMER_CAP2` etc.. as specified here where this is added as another key value pair to the Jenkins job. In this testing case, I just added `OBSERVE_CUSTOMER_2` as key and the second required environment as the value (https://www.notion.so/observeinc/tf-account-GitOps-Tutorial-fd38d97057bd40f8b615e63bbeb5325c)

```
locals {
  workspace_to_customer_map = {
    default = local.secrets["OBSERVE_CUSTOMER"]   # Default customer for tf-account 
    cap2    = local.secrets["OBSERVE_CUSTOMER_2"] # Additional customer for tf-account
  }

  customer = lookup(local.workspace_to_customer_map, terraform.workspace)

}
```