### PR TITLE
Add semvar workflow for tag updates

### DIFF
--- a/.github/workflows/semver.yaml
+++ b/.github/workflows/semver.yaml
@@ -1,0 +1,13 @@
+name: Update semver tags
+on:
+  push:
+    branches-ignore:
+      - '**'
+    tags:
+      - 'v*.*.*'
+jobs:
+  update-semver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: haya14busa/action-update-semver@v1


### PR DESCRIPTION
Added https://github.com/terraform-linters/setup-tflint/blob/master/.github/workflows/semver.yml

Updates major/minor release tags on a tag push. Eg: Update v1 and v1.2 tag when released v1.2.3.

Have tested with this before reverting:
-  https://github.com/observeinc/terraform-account-workflows/actions/runs/6226802695
- https://github.com/observeinc/tf-account-dual-terraform/actions/runs/6226814158/job/16900135487

1)`/tf-account-dual-terraform` directed to use `@v2.0` 
2) Pushed `v2.0, v2.0.1, v2.0.2` with patch changes each to `terraform-account-workflows` 
3) Checked that `/tf-account-dual-terraform` indeed used `v2.0.2` without changing anything in the workflow (still `@v2.0`) as [here](https://github.com/observeinc/tf-account-dual-terraform/blob/nikhil/dual-terraform-pipeline/.github/workflows/terraform.yml#L11) 


The tags `v2.0, v2.0.1, v2.0.2` in this repo will be deleted after this merge 