### PR TITLE
fix: updates version of gh actions 

### DIFF
--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -172,7 +172,7 @@ jobs:
           echo "path=${txt_path}" >> $GITHUB_OUTPUT
         continue-on-error: true
       
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: steps.plan.outcome == 'success'
         with:
           name: plan

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3           
       - name: Convert customer yaml to json
-        uses: fabasoad/data-format-converter-action@main
+        uses: fabasoad/data-format-converter-action@v0.3.0
         id: yaml2json
         with:
           input: ${{ github.workspace }}/${{ inputs.customers }} 


### PR DESCRIPTION
Updates version of gh actions runners that introduced breaking changes/deprecated
- fabasoad/data-format-converter-action
- upload-artifacts


Tested here: https://github.com/observeinc/tf-account-dialpad-gcp/pull/12